### PR TITLE
upgrade for gnome-shell 3.4.x, not only 3.4.1

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,1 +1,1 @@
-{"shell-version": ["3.4.1"], "uuid": "gTile@vibou", "name": "gTile", "description": "Tile your windows as you like. It even supports multiscreen ! -EDIT: - See README file for configuration -", "url" : "https://github.com/vibou/vibou.gTile"}
+{"shell-version": ["3.4"], "uuid": "gTile@vibou", "name": "gTile", "description": "Tile your windows as you like. It even supports multiscreen ! -EDIT: - See README file for configuration -", "url" : "https://github.com/vibou/vibou.gTile"}


### PR DESCRIPTION
I modified the shell-version in metadata.json to "3.4", so it works for gnome-shell 3.4.x, not only 3.4.1.

Currently I am running gnome-shell 3.4.2, and there is no problems. 
