### PR TITLE
Document that gTile is compatible with GNOME-Shell 3.6.2

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,1 +1,1 @@
-{"shell-version": ["3.6.1"], "uuid": "gTile@vibou", "name": "gTile", "description": "Tile your windows as you like. It even supports multiscreen ! -EDIT: - See README file for configuration -", "url" : "https://github.com/vibou/vibou.gTile"}
+{"shell-version": ["3.6.2"], "uuid": "gTile@vibou", "name": "gTile", "description": "Tile your windows as you like. It even supports multiscreen ! -EDIT: - See README file for configuration -", "url" : "https://github.com/vibou/vibou.gTile"}


### PR DESCRIPTION
See #16 for a statement from the @GerryT, that gTile is already compatible with GNOME-Shell 3.6.2.
