### PR TITLE
Fix git clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See https://wiki.gnome.org/Projects/GnomeShell/Extensions for details.
 1. Clone the repository to the *Gnome* extensions folder.
 
    ```
-   git clone https://github.com/lundal/vibou.gTile.git ~/.local/share/gnome-shell/extensions/gTile@vibou
+   git clone https://github.com/vibou/vibou.gTile.git ~/.local/share/gnome-shell/extensions/gTile@vibou
    ```
 
 2. Restart *Gnome*


### PR DESCRIPTION
Replace lundal by vibou in Git URL to clone.