### PR TITLE
Fix an error breaking the preferences dialog

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -66,10 +66,10 @@ function buildPrefsWidget() {
 		'accel-mode': Gtk.CellRendererAccelMode.GTK
 	});
 
-	cellrend.connect('accel-edited', function(rend, iter, key, mods) {
+	cellrend.connect('accel-edited', function(rend, str_iter, key, mods) {
 		let value = Gtk.accelerator_name(key, mods);
 		
-		let [success, iter] = model.get_iter_from_string(iter);
+		let [success, iter] = model.get_iter_from_string(str_iter);
 		
 		if (!success) {
 			throw new Error("Something be broken, yo.");


### PR DESCRIPTION
Opening the prefences window was throwing the error:
`TypeError: redeclaration of formal parameter iter`

I'll be the first to admit I don't know much about JS, so this may be a horrible change, but it fixed the issue I was seeing. 

EDIT: #65 makes this redundant.