### PR TITLE
fix: remove redundant variable declaration

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -57,7 +57,6 @@ let status;
 let launcher;
 let grids;
 let monitors;
-let tracker;
 let nbCols;
 let nbRows;
 let area;


### PR DESCRIPTION
It cause JS syntax error on systems with a fresh Node (8.7.0 for
instance) and the extension fails to start.